### PR TITLE
Persist nav bar open/closed state across visits/refreshes

### DIFF
--- a/src/display/shared/header/HeaderContainer.js
+++ b/src/display/shared/header/HeaderContainer.js
@@ -19,7 +19,8 @@ const propTypes = {
 	toggleHeaderAddMenuDropdown: PropTypes.func.isRequired,
 	toggleMobileSidebar: PropTypes.func.isRequired,
 	toggleNewsAside: PropTypes.func.isRequired,
-	toggleSidebar: PropTypes.func.isRequired,
+	loadSidebarOpen: PropTypes.func.isRequired,
+	setSidebarOpen: PropTypes.func.isRequired,
 	updateUserSettings: PropTypes.func.isRequired,
 	userSettings: PropTypes.shape({}).isRequired
 };
@@ -64,6 +65,8 @@ class HeaderContainer extends Component {
 
 	componentDidMount() {
 		this.loadBodyClasses(this.props);
+		const { loadSidebarOpen } = this.props;
+		loadSidebarOpen();
 	}
 
 	componentWillReceiveProps(nextProps) {
@@ -77,8 +80,8 @@ class HeaderContainer extends Component {
 	}
 
 	sidebarToggle() {
-		const { isSidebarOpen, toggleSidebar } = this.props;
-		toggleSidebar(!isSidebarOpen);
+		const { isSidebarOpen, setSidebarOpen } = this.props;
+		setSidebarOpen(!isSidebarOpen);
 	}
 
 	asideToggle() {
@@ -123,9 +126,11 @@ class HeaderContainer extends Component {
 	}
 
 	render() {
+		const { loadSidebarOpen, setSidebarOpen, ...props } = this.props;
+
 		return (
 			<Header
-				{...this.props}
+				{...props}
 				mobileSidebarToggle={this.mobileSidebarToggle}
 				asideToggle={this.asideToggle}
 				headerProfileDropdownToggle={this.headerProfileDropdownToggle}
@@ -141,13 +146,14 @@ class HeaderContainer extends Component {
 
 HeaderContainer.propTypes = propTypes;
 export default connect(mapStateToProps, {
+	loadSidebarOpen: actions.loadSidebarOpen,
 	openUpsertCharacterModal: actions.openUpsertCharacterModal,
 	openUpsertThreadModal: actions.openUpsertThreadModal,
+	setSidebarOpen: actions.setSidebarOpen,
 	submitUserLogout: actions.submitUserLogout,
 	toggleHeaderProfileDropdown: actions.toggleHeaderProfileDropdown,
 	toggleHeaderAddMenuDropdown: actions.toggleHeaderAddMenuDropdown,
 	toggleMobileSidebar: actions.toggleMobileSidebar,
 	toggleNewsAside: actions.toggleNewsAside,
-	toggleSidebar: actions.toggleSidebar,
 	updateUserSettings: actions.updateUserSettings
 })(HeaderContainer);

--- a/src/display/shared/header/__tests__/HeaderContainer.spec.js
+++ b/src/display/shared/header/__tests__/HeaderContainer.spec.js
@@ -13,14 +13,15 @@ jest.mock('../Header', () => 'Header');
 // #endregion mocks
 
 const createTestProps = propOverrides => ({
+	loadSidebarOpen: jest.fn(),
 	openUpsertCharacterModal: jest.fn(),
 	openUpsertThreadModal: jest.fn(),
+	setSidebarOpen: jest.fn(),
 	submitUserLogout: jest.fn(),
 	toggleHeaderProfileDropdown: jest.fn(),
 	toggleHeaderAddMenuDropdown: jest.fn(),
 	toggleMobileSidebar: jest.fn(),
 	toggleNewsAside: jest.fn(),
-	toggleSidebar: jest.fn(),
 	updateUserSettings: jest.fn(),
 	...propOverrides
 });
@@ -146,15 +147,35 @@ describe('behavior', () => {
 		});
 	});
 	describe('sidebarToggle', () => {
-		it('should dispatch sidebar toggle action', () => {
-			const toggleSidebar = jest.fn();
-			const props = createTestProps({ toggleSidebar });
-			const state = createTestState();
+		it('should dispatch setSidebarOpen action with false when open', () => {
+			const setSidebarOpen = jest.fn();
+			const props = createTestProps({ setSidebarOpen });
+			const state = createTestState({
+				ui: {
+					...createTestState().ui,
+					isSidebarOpen: true
+				}
+			});
 			const jsx = (<HeaderContainer {...props} />);
 			const element = shallowWithState(jsx, state).dive();
 			element.instance().sidebarToggle();
-			expect(toggleSidebar).toHaveBeenCalledTimes(1);
-			expect(toggleSidebar).toHaveBeenCalledWith(false);
+			expect(setSidebarOpen).toHaveBeenCalledTimes(1);
+			expect(setSidebarOpen).toHaveBeenCalledWith(false);
+		});
+		it('should dispatch setSidebarOpen action with true when not open', () => {
+			const setSidebarOpen = jest.fn();
+			const props = createTestProps({ setSidebarOpen });
+			const state = createTestState({
+				ui: {
+					...createTestState().ui,
+					isSidebarOpen: false
+				}
+			});
+			const jsx = (<HeaderContainer {...props} />);
+			const element = shallowWithState(jsx, state).dive();
+			element.instance().sidebarToggle();
+			expect(setSidebarOpen).toHaveBeenCalledTimes(1);
+			expect(setSidebarOpen).toHaveBeenCalledWith(true);
 		});
 	});
 	describe('asideToggle', () => {

--- a/src/display/shared/header/__tests__/__snapshots__/HeaderContainer.spec.js.snap
+++ b/src/display/shared/header/__tests__/__snapshots__/HeaderContainer.spec.js.snap
@@ -28,7 +28,6 @@ exports[`rendering snapshots should render valid snapshot 1`] = `
   toggleHeaderProfileDropdown={[MockFunction]}
   toggleMobileSidebar={[MockFunction]}
   toggleNewsAside={[MockFunction]}
-  toggleSidebar={[MockFunction]}
   updateUserSettings={[MockFunction]}
   user={
     Object {

--- a/src/infrastructure/actions/index.js
+++ b/src/infrastructure/actions/index.js
@@ -66,16 +66,22 @@ export {
 	LOAD_SITE_THEME_SUCCESS
 } from './ui/theme';
 export {
+	loadSidebarOpen,
+	setSidebarOpen,
+	loadSidebarOpenSuccess,
+	LOAD_SIDEBAR_OPEN,
+	SET_SIDEBAR_OPEN,
+	LOAD_SIDEBAR_OPEN_SUCCESS
+} from './ui/sidebar';
+export {
 	TOGGLE_HEADER_PROFILE_DROPDOWN,
 	TOGGLE_HEADER_ADD_MENU_DROPDOWN,
 	TOGGLE_MOBILE_SIDEBAR,
 	TOGGLE_NEWS_ASIDE,
-	TOGGLE_SIDEBAR,
 	toggleHeaderProfileDropdown,
 	toggleHeaderAddMenuDropdown,
 	toggleMobileSidebar,
-	toggleNewsAside,
-	toggleSidebar
+	toggleNewsAside
 } from './ui/toggles';
 
 // Threads

--- a/src/infrastructure/actions/ui/__tests__/sidebar.spec.js
+++ b/src/infrastructure/actions/ui/__tests__/sidebar.spec.js
@@ -1,0 +1,27 @@
+import * as actions from '../sidebar';
+
+describe('loadSidebarOpen', () => {
+	it('should create action with type', () => {
+		const action = actions.loadSidebarOpen();
+		expect(action.type).toBe('LOAD_SIDEBAR_OPEN');
+	});
+});
+describe('setSidebarOpen', () => {
+	it('should create action with type, data, and analytics', () => {
+		const data = true;
+		const action = actions.setSidebarOpen(data);
+		expect(action.type).toBe('SET_SIDEBAR_OPEN');
+		expect(action.data).toBe(data);
+		expect(action.analytics.func).toBe('event');
+		expect(action.analytics.event.category).toBe('UI');
+		expect(action.analytics.event.action).toBe('Toggled sidebar');
+	});
+});
+describe('loadSidebarOpenSuccess', () => {
+	it('should create action with type and data', () => {
+		const data = true;
+		const action = actions.loadSidebarOpenSuccess(data);
+		expect(action.type).toBe('LOAD_SIDEBAR_OPEN_SUCCESS');
+		expect(action.data).toBe(true);
+	});
+});

--- a/src/infrastructure/actions/ui/__tests__/toggles.spec.js
+++ b/src/infrastructure/actions/ui/__tests__/toggles.spec.js
@@ -44,14 +44,3 @@ describe('toggleNewsAside', () => {
 		expect(action.analytics.event.action).toBe('Toggled news aside');
 	});
 });
-describe('toggleSidebar', () => {
-	it('should create action with type, data, and analytics', () => {
-		const data = true;
-		const action = actions.toggleSidebar(data);
-		expect(action.type).toBe('TOGGLE_SIDEBAR');
-		expect(action.data).toBe(data);
-		expect(action.analytics.func).toBe('event');
-		expect(action.analytics.event.category).toBe('UI');
-		expect(action.analytics.event.action).toBe('Toggled sidebar');
-	});
-});

--- a/src/infrastructure/actions/ui/sidebar.js
+++ b/src/infrastructure/actions/ui/sidebar.js
@@ -1,0 +1,31 @@
+import analytics from '../../constants/analytics';
+
+export const LOAD_SIDEBAR_OPEN = 'LOAD_SIDEBAR_OPEN';
+export function loadSidebarOpen() {
+	return {
+		type: LOAD_SIDEBAR_OPEN
+	};
+}
+
+export const SET_SIDEBAR_OPEN = 'SET_SIDEBAR_OPEN';
+export function setSidebarOpen(value) {
+	return {
+		type: SET_SIDEBAR_OPEN,
+		data: value,
+		analytics: {
+			func: analytics.funcs.EVENT,
+			event: {
+				category: analytics.categories.UI,
+				action: 'Toggled sidebar'
+			}
+		}
+	};
+}
+
+export const LOAD_SIDEBAR_OPEN_SUCCESS = 'LOAD_SIDEBAR_OPEN_SUCCESS';
+export function loadSidebarOpenSuccess(data) {
+	return {
+		type: LOAD_SIDEBAR_OPEN_SUCCESS,
+		data
+	};
+}

--- a/src/infrastructure/actions/ui/toggles.js
+++ b/src/infrastructure/actions/ui/toggles.js
@@ -56,17 +56,3 @@ export function toggleNewsAside(value) {
 		}
 	};
 }
-export const TOGGLE_SIDEBAR = 'TOGGLE_SIDEBAR';
-export function toggleSidebar(value) {
-	return {
-		type: TOGGLE_SIDEBAR,
-		data: value,
-		analytics: {
-			func: analytics.funcs.EVENT,
-			event: {
-				category: analytics.categories.UI,
-				action: 'Toggled sidebar'
-			}
-		}
-	};
-}

--- a/src/infrastructure/constants/__tests__/__snapshots__/cacheKeys.spec.js.snap
+++ b/src/infrastructure/constants/__tests__/__snapshots__/cacheKeys.spec.js.snap
@@ -4,6 +4,7 @@ exports[`object structure should have expected values 1`] = `
 Object {
   "ACCESS_TOKEN": "accessToken",
   "REFRESH_TOKEN": "refreshToken",
+  "SIDEBAR_OPEN": "sidebarOpen",
   "USE_LIGHT_THEME": "useLightTheme",
 }
 `;

--- a/src/infrastructure/constants/cacheKeys.js
+++ b/src/infrastructure/constants/cacheKeys.js
@@ -1,5 +1,6 @@
 export default {
 	ACCESS_TOKEN: 'accessToken',
 	REFRESH_TOKEN: 'refreshToken',
-	USE_LIGHT_THEME: 'useLightTheme'
+	USE_LIGHT_THEME: 'useLightTheme',
+	SIDEBAR_OPEN: 'sidebarOpen'
 };

--- a/src/infrastructure/reducers/__tests__/ui.spec.js
+++ b/src/infrastructure/reducers/__tests__/ui.spec.js
@@ -26,13 +26,13 @@ describe('action handling', () => {
 		const result = ui(undefined, {});
 		expect(result).toEqual(getState());
 	});
-	it('should handle TOGGLE_SIDEBAR', () => {
+	it('should handle LOAD_SIDEBAR_OPEN_SUCCESS', () => {
 		const action = {
-			type: actions.TOGGLE_SIDEBAR,
+			type: actions.LOAD_SIDEBAR_OPEN_SUCCESS,
 			data: true
 		};
 		const action2 = {
-			type: actions.TOGGLE_SIDEBAR,
+			type: actions.LOAD_SIDEBAR_OPEN_SUCCESS,
 			data: false
 		};
 		const result = ui(getState(), action);

--- a/src/infrastructure/reducers/ui.js
+++ b/src/infrastructure/reducers/ui.js
@@ -18,7 +18,7 @@ import {
 	TOGGLE_HEADER_ADD_MENU_DROPDOWN,
 	TOGGLE_MOBILE_SIDEBAR,
 	TOGGLE_NEWS_ASIDE,
-	TOGGLE_SIDEBAR,
+	LOAD_SIDEBAR_OPEN_SUCCESS,
 	UNTRACK_CHARACTER,
 	UNTRACK_THREAD,
 	UPSERT_CHARACTER,
@@ -59,7 +59,7 @@ const defaultState = {
 
 function ui(state = defaultState, action) {
 	switch (action.type) {
-		case TOGGLE_SIDEBAR:
+		case LOAD_SIDEBAR_OPEN_SUCCESS:
 			return Object.assign({}, state, {
 				isSidebarOpen: action.data
 			});

--- a/src/infrastructure/sagas/index.js
+++ b/src/infrastructure/sagas/index.js
@@ -15,6 +15,8 @@ export { default as updateUserSettingsSaga } from './userSettings/updateUserSett
 // UI
 export { default as loadSiteThemeSaga } from './ui/loadSiteThemeSaga';
 export { default as setSiteThemeSaga } from './ui/setSiteThemeSaga';
+export { default as loadSideBarOpenSaga } from './ui/loadSideBarOpenSaga';
+export { default as setSiteBarOpenSaga } from './ui/setSideBarOpenSaga';
 // Threads
 export { default as exportThreadsSaga } from './threads/exportThreadsSaga';
 export { default as fetchActiveThreadsSaga } from './threads/fetchActiveThreadsSaga';

--- a/src/infrastructure/sagas/ui/__tests__/loadSideBarOpenSaga.spec.js
+++ b/src/infrastructure/sagas/ui/__tests__/loadSideBarOpenSaga.spec.js
@@ -1,0 +1,28 @@
+import loadSideBarOpenSaga from '../loadSideBarOpenSaga';
+import * as actions from '../../../actions';
+import * as cache from '../../../cache';
+import { SagaTestWrapper } from '../../../../../config/tests/helpers.unit';
+
+jest.mock('../../../cache', () => ({
+	get: jest.fn()
+}));
+describe('saga behavior', () => {
+	it('should dispatch success action with open state from cache', () => {
+		cache.get.mockReturnValue(false);
+		const saga = new SagaTestWrapper(loadSideBarOpenSaga);
+		saga.expectPut({
+			type: actions.LOAD_SIDEBAR_OPEN_SUCCESS,
+			data: false
+		});
+		return saga.execute({ type: actions.LOAD_SIDEBAR_OPEN });
+	});
+	it('should dispatch success action with side bar open by default', () => {
+		cache.get.mockReturnValue(null);
+		const saga = new SagaTestWrapper(loadSideBarOpenSaga);
+		saga.expectPut({
+			type: actions.LOAD_SIDEBAR_OPEN_SUCCESS,
+			data: true
+		});
+		return saga.execute({ type: actions.LOAD_SIDEBAR_OPEN });
+	});
+});

--- a/src/infrastructure/sagas/ui/__tests__/setSideBarOpenSaga.spec.js
+++ b/src/infrastructure/sagas/ui/__tests__/setSideBarOpenSaga.spec.js
@@ -1,0 +1,17 @@
+import setSideBarOpenSaga from '../setSideBarOpenSaga';
+import * as actions from '../../../actions';
+import { SagaTestWrapper } from '../../../../../config/tests/helpers.unit';
+
+jest.mock('../../../cache', () => ({
+	set: jest.fn()
+}));
+describe('saga behavior', () => {
+	it('should dispatch success action with theme data', () => {
+		const saga = new SagaTestWrapper(setSideBarOpenSaga);
+		saga.expectPut({
+			type: actions.LOAD_SIDEBAR_OPEN_SUCCESS,
+			data: true
+		});
+		return saga.execute({ type: actions.SET_SIDEBAR_OPEN, data: true });
+	});
+});

--- a/src/infrastructure/sagas/ui/loadSideBarOpenSaga.js
+++ b/src/infrastructure/sagas/ui/loadSideBarOpenSaga.js
@@ -1,0 +1,22 @@
+// #region imports
+import { takeEvery, put } from 'redux-saga/effects';
+import cache from '../../cache';
+import cacheKeys from '../../constants/cacheKeys';
+
+import {
+	LOAD_SIDEBAR_OPEN,
+	loadSidebarOpenSuccess
+} from '../../actions';
+// #endregion imports
+
+function* loadSidebarOpen() {
+	let sidebarOpen = cache.get(cacheKeys.SIDEBAR_OPEN);
+	if (sidebarOpen == null) {
+		sidebarOpen = true;
+	}
+	yield put(loadSidebarOpenSuccess(sidebarOpen));
+}
+
+export default function* loadSideBarOpenSaga() {
+	yield takeEvery(LOAD_SIDEBAR_OPEN, loadSidebarOpen);
+}

--- a/src/infrastructure/sagas/ui/setSideBarOpenSaga.js
+++ b/src/infrastructure/sagas/ui/setSideBarOpenSaga.js
@@ -1,0 +1,19 @@
+// #region imports
+import { takeEvery, put } from 'redux-saga/effects';
+import cache from '../../cache';
+import cacheKeys from '../../constants/cacheKeys';
+
+import {
+	SET_SIDEBAR_OPEN,
+	loadSidebarOpenSuccess
+} from '../../actions';
+// #endregion imports
+
+function* setSidebarOpen(action) {
+	cache.set(cacheKeys.SIDEBAR_OPEN, action.data);
+	yield put(loadSidebarOpenSuccess(action.data));
+}
+
+export default function* setSideBarOpenSaga() {
+	yield takeEvery(SET_SIDEBAR_OPEN, setSidebarOpen);
+}

--- a/src/infrastructure/sagas/ui/setSiteThemeSaga.js
+++ b/src/infrastructure/sagas/ui/setSiteThemeSaga.js
@@ -14,6 +14,6 @@ function* setSiteTheme(action) {
 	yield put(loadSiteThemeSuccess(action.data));
 }
 
-export default function* loadSiteThemeSaga() {
+export default function* setSiteThemeSaga() {
 	yield takeEvery(SET_SITE_THEME, setSiteTheme);
 }


### PR DESCRIPTION
This is mostly copy/pasting the same saga machinery that persists the light/dark theme.

<detail>

![navbar](https://user-images.githubusercontent.com/29510990/58433863-fc659700-8086-11e9-9404-40c8f096a7bb.gif)

</detail>