### PR TITLE
fix: row deselection for threads

### DIFF
--- a/src/display/views/threads/components/CheckboxTable.js
+++ b/src/display/views/threads/components/CheckboxTable.js
@@ -58,7 +58,7 @@ class CheckboxTable extends React.Component {
 		let { selection } = this.state;
 		const { data, onSelectionChanged } = this.props;
 		// eslint-disable-next-line no-underscore-dangle
-		const keyIndex = selection.findIndex((s) => s._id === key);
+		const keyIndex = selection.findIndex((s) => `select-${s._id}` === key);
 		if (keyIndex >= 0) {
 			selection = [...selection.slice(0, keyIndex), ...selection.slice(keyIndex + 1)];
 		} else {

--- a/src/display/views/threads/components/__tests__/CheckboxTable.spec.js
+++ b/src/display/views/threads/components/__tests__/CheckboxTable.spec.js
@@ -61,11 +61,11 @@ describe('behavior', () => {
 			});
 			const jsx = <CheckboxTable {...props} />;
 			const element = shallow(jsx);
-			element.instance().toggleSelection(1, null, {
+			element.instance().toggleSelection('select-1', null, {
 				_id: 1,
 				testProp: 'test1'
 			});
-			element.instance().toggleSelection(2, null, {
+			element.instance().toggleSelection('select-2', null, {
 				_id: 2,
 				testProp: 'test2'
 			});
@@ -88,15 +88,15 @@ describe('behavior', () => {
 			});
 			const jsx = <CheckboxTable {...props} />;
 			const element = shallow(jsx);
-			element.instance().toggleSelection(1, null, {
+			element.instance().toggleSelection('select-1', null, {
 				_id: 1,
 				testProp: 'test1'
 			});
-			element.instance().toggleSelection(2, null, {
+			element.instance().toggleSelection('select-2', null, {
 				_id: 2,
 				testProp: 'test2'
 			});
-			element.instance().toggleSelection(1, null, {
+			element.instance().toggleSelection('select-1', null, {
 				_id: 1,
 				testProp: 'test1'
 			});


### PR DESCRIPTION
## Description
This was presumably broken by undocumented breaking changes in react-table from v6.8.6 -> v6.11.5

## Motivation and Context
After selecting a thread row on the tracker, it cannot be deselected.

A current workaround is to use the "select all" checkbox, then uncheck that to reset state.

## How Has This Been Tested?
Manual testing, unit tests updated

## Screenshots (if appropriate):
This is where the new 'select-' prefix is coming from in react-table:
![image](https://user-images.githubusercontent.com/29510990/103447257-996eb580-4c56-11eb-9e7a-f3717452cad3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
