### PR TITLE
feat: support clicking/tapping anywhere on a row to select it

### DIFF
--- a/src/display/shared/columns/threads/LastPoster.js
+++ b/src/display/shared/columns/threads/LastPoster.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import columns from '../../../../infrastructure/constants/columns';
 
+const stopPropagation = (e) => e.stopPropagation();
+
 export default (lastPosters, includeFilter) => ({
 	Header: columns.LAST_POSTER.name,
 	accessor: columns.LAST_POSTER.key,
@@ -12,6 +14,7 @@ export default (lastPosters, includeFilter) => ({
 					target="_blank"
 					rel="noopener noreferrer"
 					href={row.original.status && row.original.status.lastPostUrl}
+					onClick={stopPropagation}
 				>
 					{row.value} <i className="fas fa-external-link-alt" />
 				</a>

--- a/src/display/views/threads/components/CheckboxTable.js
+++ b/src/display/views/threads/components/CheckboxTable.js
@@ -57,33 +57,13 @@ class CheckboxTable extends React.Component {
 
 	getTdProps(state, rowInfo, column, instance) {
 		const { getTdProps } = this.props;
-		const tdProps = getTdProps ? getTdProps(state, rowInfo, column, instance) : {};
-		const clickHandlerFromProps = tdProps.onClick;
-
-		return {
-			...tdProps,
-			onClick: (event, handleOriginal) => {
-				let clickHandled = false;
-				if (clickHandlerFromProps) {
-					clickHandled = clickHandlerFromProps(event, handleOriginal);
-				} else if (handleOriginal) {
-					handleOriginal();
-				}
-
-				if (column.Expander) {
-					// there's a bug in react-table where triggering selection state change
-					// undoes expansion. we can workaround because we don't selection to happen
-					// on expansion anyway
-					return;
-				}
-
-				if (!clickHandled && rowInfo) {
-					const row = rowInfo.original;
-					// eslint-disable-next-line no-underscore-dangle
-					this.toggleSelection(`select-${row._id}`, false, row);
-				}
+		return getTdProps(state, rowInfo, column, instance, () => {
+			if (rowInfo) {
+				const row = rowInfo.original;
+				// eslint-disable-next-line no-underscore-dangle
+				this.toggleSelection(`select-${row._id}`, false, row);
 			}
-		};
+		});
 	}
 
 	toggleSelection(key, shift, row) {

--- a/src/display/views/threads/components/CheckboxTable.js
+++ b/src/display/views/threads/components/CheckboxTable.js
@@ -29,6 +29,7 @@ class CheckboxTable extends React.Component {
 		};
 		this.toggleSelection = this.toggleSelection.bind(this);
 		this.getTrProps = this.getTrProps.bind(this);
+		this.getTdProps = this.getTdProps.bind(this);
 		this.toggleAll = this.toggleAll.bind(this);
 		this.isSelected = this.isSelected.bind(this);
 		this.clearSelection = this.clearSelection.bind(this);
@@ -52,6 +53,37 @@ class CheckboxTable extends React.Component {
 		}
 
 		return {};
+	}
+
+	getTdProps(state, rowInfo, column, instance) {
+		const { getTdProps } = this.props;
+		const tdProps = getTdProps ? getTdProps(state, rowInfo, column, instance) : {};
+		const clickHandlerFromProps = tdProps.onClick;
+
+		return {
+			...tdProps,
+			onClick: (event, handleOriginal) => {
+				let clickHandled = false;
+				if (clickHandlerFromProps) {
+					clickHandled = clickHandlerFromProps(event, handleOriginal);
+				} else if (handleOriginal) {
+					handleOriginal();
+				}
+
+				if (column.Expander) {
+					// there's a bug in react-table where triggering selection state change
+					// undoes expansion. we can workaround because we don't selection to happen
+					// on expansion anyway
+					return;
+				}
+
+				if (!clickHandled && rowInfo) {
+					const row = rowInfo.original;
+					// eslint-disable-next-line no-underscore-dangle
+					this.toggleSelection(`select-${row._id}`, false, row);
+				}
+			}
+		};
 	}
 
 	toggleSelection(key, shift, row) {
@@ -115,7 +147,6 @@ class CheckboxTable extends React.Component {
 			noDataText,
 			defaultFilterMethod,
 			SubComponent,
-			getTdProps,
 			defaultSorted,
 			defaultPageSize,
 			onPageSizeChange
@@ -141,8 +172,8 @@ class CheckboxTable extends React.Component {
 					defaultPageSize={defaultPageSize}
 					onPageSizeChange={onPageSizeChange}
 					columns={columns}
-					getTdProps={getTdProps}
 					getTrProps={this.getTrProps}
+					getTdProps={this.getTdProps}
 					defaultSorted={defaultSorted}
 					defaultFilterMethod={defaultFilterMethod}
 					showPaginationTop

--- a/src/display/views/threads/components/__tests__/CheckboxTable.spec.js
+++ b/src/display/views/threads/components/__tests__/CheckboxTable.spec.js
@@ -130,58 +130,43 @@ describe('behavior', () => {
 			element.update();
 			expect(element.find('RTSelectTable').props().selectAll).toBe(true);
 		});
-		it('should select item when row is clicked, forwarding to callbacks from props', () => {
+		it('should support toggling selection from td props, to allow clicking empty space on the row to select it', () => {
 			const onSelectionChanged = jest.fn();
-			const originalOnClick = jest.fn();
 			const props = createTestProps({
 				onSelectionChanged,
-				getTdProps: jest.fn(() => ({
-					onClick: originalOnClick
-				}))
+				getTdProps: jest.fn(() => ({}))
 			});
 			const state = {};
 			const rowInfo = { original: props.data[0] };
 			const column = {};
 			const instance = {};
-			const event = {};
-			const handleOriginal = jest.fn();
 			const jsx = <CheckboxTable {...props} />;
 			const element = shallow(jsx);
-			const tdProps = element.instance().getTdProps(state, rowInfo, column, instance);
-			tdProps.onClick(event, handleOriginal);
-			expect(props.getTdProps).toBeCalledWith(state, rowInfo, column, instance);
-			expect(originalOnClick).toBeCalledWith(event, handleOriginal);
+			element.instance().getTdProps(state, rowInfo, column, instance);
+			expect(props.getTdProps).toBeCalledWith(
+				state,
+				rowInfo,
+				column,
+				instance,
+				expect.any(Function)
+			);
+			const toggleSelectionCallback = props.getTdProps.mock.calls[0][4];
+			toggleSelectionCallback();
 			expect(onSelectionChanged).toHaveBeenCalledTimes(1);
 			expect(onSelectionChanged).toHaveBeenLastCalledWith([{ _id: 1, testProp: 'test1' }]);
 		});
 		it('should color selected rows', () => {
-			const props = createTestProps({});
+			const props = createTestProps({
+				getTdProps: jest.fn(() => ({}))
+			});
 			const rowInfo = { original: props.data[0] };
 			const jsx = <CheckboxTable {...props} />;
 			const element = shallow(jsx);
-			const tdProps = element.instance().getTdProps({}, rowInfo, {}, {});
-			tdProps.onClick({}, jest.fn());
+			element.instance().getTdProps({}, rowInfo, {}, {});
+			const toggleSelectionCallback = props.getTdProps.mock.calls[0][4];
+			toggleSelectionCallback();
 			const trProps = element.instance().getTrProps({}, rowInfo);
 			expect(typeof trProps.style.backgroundColor).toBe('string');
-		});
-		it('should not toggle selection when an expander cell is clicked', () => {
-			const onSelectionChanged = jest.fn();
-			const props = createTestProps({
-				onSelectionChanged,
-				getTdProps: jest.fn(() => ({
-					onClick: jest.fn(),
-				}))
-			});
-			const state = {};
-			const rowInfo = { original: props.data[0] };
-			const column = { Expander: {} };
-			const instance = {};
-			const event = {};
-			const jsx = <CheckboxTable {...props} />;
-			const element = shallow(jsx);
-			const tdProps = element.instance().getTdProps(state, rowInfo, column, instance);
-			tdProps.onClick(event, jest.fn());
-			expect(onSelectionChanged).not.toHaveBeenCalled();
 		});
 		it('should set select-all checkbox checked when selected items length equals row length', () => {});
 	});

--- a/src/display/views/threads/components/__tests__/CheckboxTable.spec.js
+++ b/src/display/views/threads/components/__tests__/CheckboxTable.spec.js
@@ -81,7 +81,7 @@ describe('behavior', () => {
 				}
 			]);
 		});
-		it('should trigger onSelectionChanged when item is added', () => {
+		it('should trigger onSelectionChanged when item is removed', () => {
 			const onSelectionChanged = jest.fn();
 			const props = createTestProps({
 				onSelectionChanged
@@ -129,6 +129,40 @@ describe('behavior', () => {
 			});
 			element.update();
 			expect(element.find('RTSelectTable').props().selectAll).toBe(true);
+		});
+		it('should select item when row is clicked, forwarding to callbacks from props', () => {
+			const onSelectionChanged = jest.fn();
+			const originalOnClick = jest.fn();
+			const props = createTestProps({
+				onSelectionChanged,
+				getTdProps: jest.fn(() => ({
+					onClick: originalOnClick
+				}))
+			});
+			const state = {};
+			const rowInfo = { original: props.data[0] };
+			const column = {};
+			const instance = {};
+			const event = {};
+			const handleOriginal = jest.fn();
+			const jsx = <CheckboxTable {...props} />;
+			const element = shallow(jsx);
+			const tdProps = element.instance().getTdProps(state, rowInfo, column, instance);
+			tdProps.onClick(event, handleOriginal);
+			expect(props.getTdProps).toBeCalledWith(state, rowInfo, column, instance);
+			expect(originalOnClick).toBeCalledWith(event, handleOriginal);
+			expect(onSelectionChanged).toHaveBeenCalledTimes(1);
+			expect(onSelectionChanged).toHaveBeenLastCalledWith([{ _id: 1, testProp: 'test1' }]);
+		});
+		it('should color selected rows', () => {
+			const props = createTestProps({});
+			const rowInfo = { original: props.data[0] };
+			const jsx = <CheckboxTable {...props} />;
+			const element = shallow(jsx);
+			const tdProps = element.instance().getTdProps({}, rowInfo, {}, {});
+			tdProps.onClick({}, jest.fn());
+			const trProps = element.instance().getTrProps({}, rowInfo);
+			expect(typeof trProps.style.backgroundColor).toBe('string');
 		});
 		it('should set select-all checkbox checked when selected items length equals row length', () => {});
 	});
@@ -186,7 +220,7 @@ describe('behavior', () => {
 			const isSelected = element.instance().isSelected(1);
 			expect(isSelected).toBe(true);
 		});
-		it('should return true if item is not selected', () => {
+		it('should return false if item is not selected', () => {
 			const props = createTestProps();
 			const jsx = <CheckboxTable {...props} />;
 			const element = mount(jsx);

--- a/src/display/views/threads/components/__tests__/CheckboxTable.spec.js
+++ b/src/display/views/threads/components/__tests__/CheckboxTable.spec.js
@@ -164,6 +164,25 @@ describe('behavior', () => {
 			const trProps = element.instance().getTrProps({}, rowInfo);
 			expect(typeof trProps.style.backgroundColor).toBe('string');
 		});
+		it('should not toggle selection when an expander cell is clicked', () => {
+			const onSelectionChanged = jest.fn();
+			const props = createTestProps({
+				onSelectionChanged,
+				getTdProps: jest.fn(() => ({
+					onClick: jest.fn(),
+				}))
+			});
+			const state = {};
+			const rowInfo = { original: props.data[0] };
+			const column = { Expander: {} };
+			const instance = {};
+			const event = {};
+			const jsx = <CheckboxTable {...props} />;
+			const element = shallow(jsx);
+			const tdProps = element.instance().getTdProps(state, rowInfo, column, instance);
+			tdProps.onClick(event, jest.fn());
+			expect(onSelectionChanged).not.toHaveBeenCalled();
+		});
 		it('should set select-all checkbox checked when selected items length equals row length', () => {});
 	});
 	describe('toggleAll', () => {

--- a/src/display/views/threads/components/__tests__/_getTdProps.spec.js
+++ b/src/display/views/threads/components/__tests__/_getTdProps.spec.js
@@ -91,6 +91,22 @@ describe('behavior', () => {
 			});
 		});
 	});
+	describe('return value', () => {
+		it('should return true if onClick handled the action', () => {
+			const clickedColumn = { id: 'editButton' };
+			const propsCreator = _getTdProps(jest.fn(), jest.fn(), jest.fn(), jest.fn());
+			const props = propsCreator({}, { original: {} }, clickedColumn);
+			const result = props.onClick({}, jest.fn());
+			expect(result).toBe(true);
+		});
+		it('should return false if onClick did not handle the action', () => {
+			const clickedColumn = { id: 'unrecognized' };
+			const propsCreator = _getTdProps(jest.fn(), jest.fn(), jest.fn(), jest.fn());
+			const props = propsCreator({}, { original: {} }, clickedColumn);
+			const result = props.onClick({}, jest.fn());
+			expect(result).toBe(false);
+		});
+	});
 	describe('handleOriginal', () => {
 		it('should fall back to handleOriginal in other cases', () => {
 			const clickedColumn = {

--- a/src/display/views/threads/components/__tests__/_getTdProps.spec.js
+++ b/src/display/views/threads/components/__tests__/_getTdProps.spec.js
@@ -91,20 +91,30 @@ describe('behavior', () => {
 			});
 		});
 	});
-	describe('return value', () => {
-		it('should return true if onClick handled the action', () => {
+	describe('row selection', () => {
+		it('should not toggle row selection if onClick handled the action', () => {
 			const clickedColumn = { id: 'editButton' };
+			const toggleSelection = jest.fn();
 			const propsCreator = _getTdProps(jest.fn(), jest.fn(), jest.fn(), jest.fn());
-			const props = propsCreator({}, { original: {} }, clickedColumn);
-			const result = props.onClick({}, jest.fn());
-			expect(result).toBe(true);
+			const props = propsCreator({}, { original: {} }, clickedColumn, {}, toggleSelection);
+			props.onClick({}, jest.fn());
+			expect(toggleSelection).not.toBeCalled();
 		});
-		it('should return false if onClick did not handle the action', () => {
+		it('should toggle row selection if onClick did not handle the action', () => {
 			const clickedColumn = { id: 'unrecognized' };
+			const toggleSelection = jest.fn();
 			const propsCreator = _getTdProps(jest.fn(), jest.fn(), jest.fn(), jest.fn());
-			const props = propsCreator({}, { original: {} }, clickedColumn);
-			const result = props.onClick({}, jest.fn());
-			expect(result).toBe(false);
+			const props = propsCreator({}, { original: {} }, clickedColumn, {}, toggleSelection);
+			props.onClick({}, jest.fn());
+			expect(toggleSelection).toBeCalled();
+		});
+		it('should not toggle row selection if onClick did not handle the action and the column is an Expander', () => {
+			const clickedColumn = { id: 'unrecognized', Expander: jest.fn() };
+			const toggleSelection = jest.fn();
+			const propsCreator = _getTdProps(jest.fn(), jest.fn(), jest.fn(), jest.fn());
+			const props = propsCreator({}, { original: {} }, clickedColumn, {}, toggleSelection);
+			props.onClick({}, jest.fn());
+			expect(toggleSelection).not.toBeCalled();
 		});
 	});
 	describe('handleOriginal', () => {
@@ -121,7 +131,7 @@ describe('behavior', () => {
 			};
 			const handleOriginal = jest.fn();
 			const propsCreator = _getTdProps(jest.fn(), jest.fn(), jest.fn(), jest.fn());
-			const props = propsCreator({}, clickedRow, clickedColumn);
+			const props = propsCreator({}, clickedRow, clickedColumn, {}, jest.fn());
 			props.onClick({}, handleOriginal);
 			expect(handleOriginal).toHaveBeenCalledTimes(1);
 		});
@@ -137,7 +147,7 @@ describe('behavior', () => {
 				}
 			};
 			const propsCreator = _getTdProps(jest.fn(), jest.fn(), jest.fn(), jest.fn());
-			const props = propsCreator({}, clickedRow, clickedColumn);
+			const props = propsCreator({}, clickedRow, clickedColumn, {}, jest.fn());
 			props.onClick({}, null);
 			expect(true).toBe(true);
 		});

--- a/src/display/views/threads/components/_getTdProps.js
+++ b/src/display/views/threads/components/_getTdProps.js
@@ -5,23 +5,24 @@ const getTdProps = (onDeleteTrigger, onEditTrigger, onArchiveTrigger, onQueueTri
 		onClick: (e, handleOriginal) => {
 			if (column.id === columns.DELETE_BUTTON.key) {
 				onDeleteTrigger(row.original.thread);
-				return;
+				return true;
 			}
 			if (column.id === columns.EDIT_BUTTON.key) {
 				onEditTrigger(row.original.thread);
-				return;
+				return true;
 			}
 			if (column.id === columns.ARCHIVE_BUTTON.key) {
 				onArchiveTrigger(row.original.thread);
-				return;
+				return true;
 			}
 			if (column.id === columns.QUEUE_BUTTON.key) {
 				onQueueTrigger(row.original.thread);
-				return;
+				return true;
 			}
 			if (handleOriginal) {
 				handleOriginal();
 			}
+			return false;
 		}
 	});
 	return generateTdProps;

--- a/src/display/views/threads/components/_getTdProps.js
+++ b/src/display/views/threads/components/_getTdProps.js
@@ -1,28 +1,36 @@
 import columns from '../../../../infrastructure/constants/columns';
 
 const getTdProps = (onDeleteTrigger, onEditTrigger, onArchiveTrigger, onQueueTrigger) => {
-	const generateTdProps = (state, row, column) => ({
+	const generateTdProps = (state, row, column, _instance, toggleSelection) => ({
 		onClick: (e, handleOriginal) => {
 			if (column.id === columns.DELETE_BUTTON.key) {
 				onDeleteTrigger(row.original.thread);
-				return true;
+				return;
 			}
 			if (column.id === columns.EDIT_BUTTON.key) {
 				onEditTrigger(row.original.thread);
-				return true;
+				return;
 			}
 			if (column.id === columns.ARCHIVE_BUTTON.key) {
 				onArchiveTrigger(row.original.thread);
-				return true;
+				return;
 			}
 			if (column.id === columns.QUEUE_BUTTON.key) {
 				onQueueTrigger(row.original.thread);
-				return true;
+				return;
 			}
+
+			// there's a bug in react-table where triggering selection state change
+			// undoes expansion. this manifests as the expand button not doing anything
+			// when clicked. we can workaround because we don't selection to happen
+			// on expansion anyway
+			if (!column.Expander) {
+				toggleSelection();
+			}
+
 			if (handleOriginal) {
 				handleOriginal();
 			}
-			return false;
 		}
 	});
 	return generateTdProps;


### PR DESCRIPTION
## Description
Support clicking/tapping anywhere on a row to select it

Addresses item 3 in #135

![click-to-select](https://user-images.githubusercontent.com/29510990/103467001-65f45f80-4d18-11eb-911b-309e94f9047e.gif)

## Motivation and Context
No long requires clicking on the little checkbox to select a row

## How Has This Been Tested?
Manual testing via local dev, unit tests added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
