### PR TITLE
Dark sidebar when dark theme selected

### DIFF
--- a/src/display/shared/sidebar/_styles.js
+++ b/src/display/shared/sidebar/_styles.js
@@ -11,7 +11,10 @@ export default styled.div`
   }
 	.nav {
 		.nav-title {
-			color: ${colors.GRAY_600}
+			color: ${colors.GRAY_100};
+      .light-theme & {
+        color: ${colors.GRAY_600}
+      }
 		}
 		.nav-item {
 			.nav-link {
@@ -20,7 +23,7 @@ export default styled.div`
           color: ${colors.GRAY_600}
         }
 				i {
-					color: ${colors.GRAY_100};
+					color: ${colors.GRAY_100}; 
           .light-theme & {
             color: ${colors.GRAY_600}
           }

--- a/src/display/shared/sidebar/_styles.js
+++ b/src/display/shared/sidebar/_styles.js
@@ -29,8 +29,12 @@ export default styled.div`
           }
 				}
 				&.active {
-					background: ${colors.GRAY_050};
-					color: ${colors.GRAY_600};
+					background: ${colors.GRAY_600};
+					color: ${colors.GRAY_050};
+          .light-theme & {
+            background: ${colors.GRAY_050};
+            color: ${colors.GRAY_600};
+          }
 					i {
 						color: ${colors.LIGHT_BLUE};
 					}

--- a/src/display/shared/sidebar/_styles.js
+++ b/src/display/shared/sidebar/_styles.js
@@ -15,9 +15,15 @@ export default styled.div`
 		}
 		.nav-item {
 			.nav-link {
-				color: ${colors.GRAY_600}
+				color: ${colors.GRAY_100};
+        .light-theme & {
+          color: ${colors.GRAY_600}
+        }
 				i {
-					color: ${colors.GRAY_600}
+					color: ${colors.GRAY_100};
+          .light-theme & {
+            color: ${colors.GRAY_600}
+          }
 				}
 				&.active {
 					background: ${colors.GRAY_050};

--- a/src/display/shared/sidebar/_styles.js
+++ b/src/display/shared/sidebar/_styles.js
@@ -2,9 +2,13 @@ import styled from 'styled-components';
 import colors from '../../../infrastructure/constants/colors';
 
 export default styled.div`
-	color: ${colors.GRAY_400};
-	background: ${colors.WHITE};
+	color: ${colors.GRAY_100};
+	background: ${colors.GRAY_900};
 	border-right: 1px solid ${colors.GRAY_200};
+  .light-theme & {
+	  color: ${colors.GRAY_400};
+	  background: ${colors.WHITE};
+  }
 	.nav {
 		.nav-title {
 			color: ${colors.GRAY_600}

--- a/src/display/shared/sidebar/_styles.js
+++ b/src/display/shared/sidebar/_styles.js
@@ -4,10 +4,11 @@ import colors from '../../../infrastructure/constants/colors';
 export default styled.div`
 	color: ${colors.GRAY_100};
 	background: ${colors.GRAY_900};
-	border-right: 1px solid ${colors.GRAY_200};
+	border-right: 1px solid ${colors.GRAY_400};
   .light-theme & {
 	  color: ${colors.GRAY_400};
 	  background: ${colors.WHITE};
+    border-right: 1px solid ${colors.GRAY_200};
   }
 	.nav {
 		.nav-title {


### PR DESCRIPTION
## Description
Updated navbar styles so sidebar appears in dark theme colours when dark theme is selected, and stays in light theme colours when light theme is selected.

## Motivation and Context
Addresses item 5 in [#135](https://github.com/blackjackkent/RPThreadTrackerV3.FrontEnd/issues/135)
People using dark mode will no longer be blinded by the sidebar

## How Has This Been Tested?
I ran the navbar styles test.
I did manual testing in dark and light mode.

## Screenshots (if appropriate):
![dark](https://user-images.githubusercontent.com/42087659/115749746-52383c00-a38f-11eb-97dd-c520029f3905.png)
![light](https://user-images.githubusercontent.com/42087659/115749750-52d0d280-a38f-11eb-9933-6e4e53937523.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.