### PR TITLE
Moved nav toggle to left of title

### DIFF
--- a/src/display/shared/header/components/HeaderLogoBlock.js
+++ b/src/display/shared/header/components/HeaderLogoBlock.js
@@ -26,9 +26,6 @@ const HeaderLogoBlock = (props) => {
 			>
 				&#9776;
 			</NavbarToggler>
-			<Link href="/" className="d-none d-sm-inline-block navbar-brand" to="/">
-				RPTHREADTRACKER
-			</Link>
 			<NavbarToggler
 				className="d-md-down-none"
 				data-spec="header-logo-block-sidebar-toggler"
@@ -36,6 +33,9 @@ const HeaderLogoBlock = (props) => {
 			>
 				&#9776;
 			</NavbarToggler>
+			<Link href="/" className="d-none d-sm-inline-block navbar-brand" to="/">
+				RPTHREADTRACKER
+			</Link>
 		</div>
 	);
 };

--- a/src/display/shared/header/components/__tests__/__snapshots__/HeaderLogoBlock.spec.js.snap
+++ b/src/display/shared/header/components/__tests__/__snapshots__/HeaderLogoBlock.spec.js.snap
@@ -17,14 +17,6 @@ exports[`rendering snapshots should render valid snapshot 1`] = `
   >
     ☰
   </NavbarToggler>
-  <Link
-    className="d-none d-sm-inline-block navbar-brand"
-    href="/"
-    replace={false}
-    to="/"
-  >
-    RPTHREADTRACKER
-  </Link>
   <NavbarToggler
     className="d-md-down-none"
     data-spec="header-logo-block-sidebar-toggler"
@@ -34,5 +26,13 @@ exports[`rendering snapshots should render valid snapshot 1`] = `
   >
     ☰
   </NavbarToggler>
+  <Link
+    className="d-none d-sm-inline-block navbar-brand"
+    href="/"
+    replace={false}
+    to="/"
+  >
+    RPTHREADTRACKER
+  </Link>
 </div>
 `;

--- a/src/display/shared/sidebar/_styles.js
+++ b/src/display/shared/sidebar/_styles.js
@@ -11,7 +11,10 @@ export default styled.div`
   }
 	.nav {
 		.nav-title {
-			color: ${colors.GRAY_600}
+			color: ${colors.GRAY_100};
+      .light-theme & {
+        color: ${colors.GRAY_600}
+      }
 		}
 		.nav-item {
 			.nav-link {
@@ -20,7 +23,7 @@ export default styled.div`
           color: ${colors.GRAY_600}
         }
 				i {
-					color: ${colors.GRAY_100};
+					color: ${colors.GRAY_100}; 
           .light-theme & {
             color: ${colors.GRAY_600}
           }

--- a/src/display/shared/sidebar/_styles.js
+++ b/src/display/shared/sidebar/_styles.js
@@ -29,8 +29,12 @@ export default styled.div`
           }
 				}
 				&.active {
-					background: ${colors.GRAY_050};
-					color: ${colors.GRAY_600};
+					background: ${colors.GRAY_600};
+					color: ${colors.GRAY_050};
+          .light-theme & {
+            background: ${colors.GRAY_050};
+            color: ${colors.GRAY_600};
+          }
 					i {
 						color: ${colors.LIGHT_BLUE};
 					}

--- a/src/display/shared/sidebar/_styles.js
+++ b/src/display/shared/sidebar/_styles.js
@@ -15,9 +15,15 @@ export default styled.div`
 		}
 		.nav-item {
 			.nav-link {
-				color: ${colors.GRAY_600}
+				color: ${colors.GRAY_100};
+        .light-theme & {
+          color: ${colors.GRAY_600}
+        }
 				i {
-					color: ${colors.GRAY_600}
+					color: ${colors.GRAY_100};
+          .light-theme & {
+            color: ${colors.GRAY_600}
+          }
 				}
 				&.active {
 					background: ${colors.GRAY_050};

--- a/src/display/shared/sidebar/_styles.js
+++ b/src/display/shared/sidebar/_styles.js
@@ -2,9 +2,13 @@ import styled from 'styled-components';
 import colors from '../../../infrastructure/constants/colors';
 
 export default styled.div`
-	color: ${colors.GRAY_400};
-	background: ${colors.WHITE};
+	color: ${colors.GRAY_100};
+	background: ${colors.GRAY_900};
 	border-right: 1px solid ${colors.GRAY_200};
+  .light-theme & {
+	  color: ${colors.GRAY_400};
+	  background: ${colors.WHITE};
+  }
 	.nav {
 		.nav-title {
 			color: ${colors.GRAY_600}

--- a/src/display/shared/sidebar/_styles.js
+++ b/src/display/shared/sidebar/_styles.js
@@ -4,10 +4,11 @@ import colors from '../../../infrastructure/constants/colors';
 export default styled.div`
 	color: ${colors.GRAY_100};
 	background: ${colors.GRAY_900};
-	border-right: 1px solid ${colors.GRAY_200};
+	border-right: 1px solid ${colors.GRAY_400};
   .light-theme & {
 	  color: ${colors.GRAY_400};
 	  background: ${colors.WHITE};
+    border-right: 1px solid ${colors.GRAY_200};
   }
 	.nav {
 		.nav-title {


### PR DESCRIPTION
## Description
Swapped the positions of the title and nav toggle, so the nag toggle is on the left of the tiel.

## Motivation and Context
Fixes issue [165](https://github.com/blackjackkent/RPThreadTrackerV3.FrontEnd/issues/165)

## How Has This Been Tested?
Tested in various browsers in Linux Mint and Windows 10.
Also re-ran relevant tests

## Screenshots (if appropriate):
Before (Windows):
![before windows](https://user-images.githubusercontent.com/42087659/115956170-36e64180-a4f3-11eb-9c7f-2e0bf091954b.png)

Before (Linux)
![before linux](https://user-images.githubusercontent.com/42087659/115956174-3b125f00-a4f3-11eb-9d7b-1d92b5ef3dbc.png)

After (both):
![after](https://user-images.githubusercontent.com/42087659/115956176-406fa980-a4f3-11eb-9660-eb7c3659c581.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
