### PR TITLE
Fixing missing default value for page size

### DIFF
--- a/src/display/views/threads/components/ThreadTableWrapper.js
+++ b/src/display/views/threads/components/ThreadTableWrapper.js
@@ -148,7 +148,7 @@ const ThreadTableWrapper = ({
 						onEditThreadClick={onEditThreadClick}
 						onArchiveThreadClick={onArchiveThreadClick}
 						onQueueThreadClick={onQueueThreadClick}
-						threadTablePageSize={userSettings?.threadTablePageSize}
+						threadTablePageSize={userSettings?.threadTablePageSize || 10}
 						onThreadTablePageSizeChange={onThreadTablePageSizeChange}
 						onSelectedThreadsChange={onSelectedThreadsChange}
 					/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes a bug which caused the thread views to crash if the user's account did not have a default page size selected (i.e. if they had never changed from the default 10 threads per page).