### PR TITLE
Add key to header modals to force remount on modal close

### DIFF
--- a/src/display/shared/header/HeaderContainer.js
+++ b/src/display/shared/header/HeaderContainer.js
@@ -68,12 +68,14 @@ const HeaderContainer = () => {
 	return (
 		<Style className="app-header navbar">
 			<UpsertThreadModal
+				key={`upsert-thread-modal-open-${isUpsertThreadModalOpen}`}
 				actedThread={{}}
 				characters={characters}
 				isModalOpen={isUpsertThreadModalOpen}
 				setIsModalOpen={setIsUpsertThreadModalOpen}
 			/>
 			<UpsertCharacterModal
+				key={`upsert-character-modal-open-${isUpsertCharacterModalOpen}`}
 				actedCharacter={{}}
 				isModalOpen={isUpsertCharacterModalOpen}
 				setIsModalOpen={setIsUpsertCharacterModalOpen}


### PR DESCRIPTION
## Description
Adds key to header modals to force remount on modal close.

## Motivation and Context
Modal was retaining info from previous form submission when reopened (if a user was adding multiple threads at once).

## How Has This Been Tested?
UAT.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
